### PR TITLE
Adding in the ability to serve static resources

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -18,7 +18,7 @@ var argv = optimist
   .describe('port', 'Starts listening on that port and waits for you to open a browser')
   .alias('p', 'port')
 
-  .describe('static', 'Allows you to serve static assets from the directory the test command is ran from')
+  .describe('static', 'Serve static assets from directory specified in static option')
   .alias('s', 'static')
 
 

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ var fs = require('fs');
 var xws = require('xhr-write-stream')();
 var enstore = require('enstore');
 var launcher = require('browser-launcher');
+var ecstatic = require('ecstatic');
 
 module.exports = function (opts) {
   if (!opts) opts = {};
   if ('number' == typeof opts) opts = { port: opts };
   if (!opts.browser) opts.browser = 'phantom';
-  opts.static = !!opts.static;
   return runner(opts);
 };
 
@@ -46,13 +46,7 @@ function runner (opts) {
     }
 
     if ( opts.static ) {
-      fs.exists( process.cwd() + req.url, function( exist ) {
-        if ( exist ) {
-          fs.createReadStream( process.cwd() + req.url ).pipe( res );
-          return;
-        }
-        res.end('not supported');
-      } );
+      ecstatic({ root: opts.static })( req, res );
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "browser-launcher": "~0.3.4",
     "browserify": "~5.9.3",
     "duplexer": "0.0.3",
+    "ecstatic": "^0.5.8",
     "enstore": "~0.0.1",
     "optimist": "~0.3.5",
     "through": "~2.2.7",


### PR DESCRIPTION
This is allows you to serve up static resources using the same server that browser-run is using.
### example usage

``` javascript
var run = require( '../' );

var browser = run( {
    static: true
} );
browser.pipe( process.stdout );
browser.write(
    'var img = document.createElement( \'img\' ); ' + 
    'img.onload = function(){ console.log( \'img loaded\' )}; ' +
    'img.onerror = function( err ){ console.log( \'img errored\', err )}; ' +  
    'img.src = \'./examples/foo.png\'; ' +
    'document.body.appendChild( img );' 
);
browser.end();
```

If the resource is there then it will log "image loaded"

Also I was thinking on how we could test this let me know if you have any ideas

once this is merged I think I can have a pr ready for `tape-run` to be able to pass this flag.
