### PR TITLE
input format option - allow html input

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Returns a duplex stream and starts a webserver.
   * `phantom`
   * `safari`
 * `static`: Serve static files from this directory
+* `input`: Input type. Defaults to `javascript`, can be set to `html`.
 
 If only an empty string is written to it, an error will be thrown as there is nothing to execute.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "duplexer": "0.0.3",
     "ecstatic": "^0.5.8",
     "enstore": "~0.0.1",
+    "html-inject-script": "^1.0.0",
     "optimist": "~0.3.5",
     "phantomjs-stream": "^1.0.0",
     "through": "~2.2.7",


### PR DESCRIPTION
if input is set to `html`, it takes stdin, injects a reporter.js script tag, and serves the result as the index.html file