### PR TITLE
Updated ecstatic to version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "browser-launcher": "0.3.5",
     "duplexer": "0.0.3",
-    "ecstatic": "1.1.0",
+    "ecstatic": "1.1.1",
     "enstore": "0.0.2",
     "html-inject-script": "1.1.0",
     "optimist": "0.6.1",


### PR DESCRIPTION
:rocket:

ecstatic just published version 1.1.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [70920b4](https://github.com/jfhbrook/node-ecstatic/commit/70920b4812a9d6bb3a2727cb6295da72518cde6f): Release 1.1.1
- [a7fdc17](https://github.com/jfhbrook/node-ecstatic/commit/a7fdc17e10c0fae8851929fb5cc4ece506d3f610): Merge pull request #160 from substack/boolean
- [46897ff](https://github.com/jfhbrook/node-ecstatic/commit/46897ffa5b6932c07e9b463c1aba71eebe0a0648): boolean options

See the [full diff](https://github.com/jfhbrook/node-ecstatic/compare/a251068a94ac37cccc17757b7d7f398a8ab7868a...70920b4812a9d6bb3a2727cb6295da72518cde6f).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>