### PR TITLE
Updated ecstatic to version 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "browser-launcher": "0.3.5",
     "duplexer": "0.0.3",
-    "ecstatic": "1.1.0",
+    "ecstatic": "1.1.2",
     "enstore": "0.0.2",
     "html-inject-script": "1.1.0",
     "optimist": "0.6.1",


### PR DESCRIPTION
:rocket:

ecstatic just published version 1.1.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 8 commits (ahead by 8, behind by 0).

- [3a7d2e6](https://github.com/jfhbrook/node-ecstatic/commit/3a7d2e67b58e268cc2835eb8ab74f90f88b97c2f): Release 1.1.2
- [061c423](https://github.com/jfhbrook/node-ecstatic/commit/061c42310a295c6406c169cda7ff13150044ab36): Merge pull request #161 from substack/boolean
- [77d9a7d](https://github.com/jfhbrook/node-ecstatic/commit/77d9a7d212ee1f69b3a1517c90aa9860eb4c7240): fix for options handler from --cors to not get unset
- [3fd60d6](https://github.com/jfhbrook/node-ecstatic/commit/3fd60d6f5b2171f53ac0e6dfa723420b4738760a): require the correct file
- [59e63bf](https://github.com/jfhbrook/node-ecstatic/commit/59e63bfc3102188a3945712158775b8e027c3ae2): share defaults and aliases between opts handler and minimist
- [70920b4](https://github.com/jfhbrook/node-ecstatic/commit/70920b4812a9d6bb3a2727cb6295da72518cde6f): Release 1.1.1
- [a7fdc17](https://github.com/jfhbrook/node-ecstatic/commit/a7fdc17e10c0fae8851929fb5cc4ece506d3f610): Merge pull request #160 from substack/boolean
- [46897ff](https://github.com/jfhbrook/node-ecstatic/commit/46897ffa5b6932c07e9b463c1aba71eebe0a0648): boolean options

See the [full diff](https://github.com/jfhbrook/node-ecstatic/compare/a251068a94ac37cccc17757b7d7f398a8ab7868a...3a7d2e67b58e268cc2835eb8ab74f90f88b97c2f).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>