### PR TITLE
Updated ecstatic to version 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "browser-launcher": "0.3.5",
     "duplexer": "0.0.3",
-    "ecstatic": "1.1.2",
+    "ecstatic": "1.1.3",
     "enstore": "0.0.2",
     "html-inject-script": "1.1.0",
     "optimist": "0.6.1",


### PR DESCRIPTION
:rocket:

ecstatic just published version 1.1.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [3102858](https://github.com/jfhbrook/node-ecstatic/commit/3102858ac2190a059ad4bf4ede888da092ce9c90): Release 1.1.3
- [dd62194](https://github.com/jfhbrook/node-ecstatic/commit/dd621942f5c8562a99ed268701260e688944c7b6): Merge pull request #162 from substack/cors-boolean-fix
- [e48e077](https://github.com/jfhbrook/node-ecstatic/commit/e48e0779decab428303ee603364c1255233a59c4): set cors to false to enable booleanism on the command-line

See the [full diff](https://github.com/jfhbrook/node-ecstatic/compare/3a7d2e67b58e268cc2835eb8ab74f90f88b97c2f...3102858ac2190a059ad4bf4ede888da092ce9c90).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>