### PR TITLE
wrap server.destroy() in try/catch in stop method

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function runner (opts) {
   }
 
   dpl.stop = function () {
-    server.destroy();
+    try { server.destroy(); } catch (e) {}
     if (browser) browser.kill();
   };
 


### PR DESCRIPTION
When I clone, install, and run tests on https://github.com/juliangruber/tape-run without making any changes, I get the following error:

```
~/tape-run master
❯ npm run test

> tape-run@2.1.2 test /Users/rtsao/tape-run
> make test

TAP version 13
# api: one
ok 1 should be equal
# api: fail
ok 2 should be equal
# api: error

net.js:1236
    throw new Error('Not running');
          ^
Error: Not running
    at Server.close (net.js:1236:11)
    at Server.server.destroy (/Users/rtsao/tape-run/node_modules/server-destroy/index.js:15:12)
    at Stream.dpl.stop (/Users/rtsao/tape-run/node_modules/browser-run/index.js:105:12)
    at Stream.<anonymous> (/Users/rtsao/tape-run/index.js:17:15)
    at Stream.f (/Users/rtsao/tape-run/node_modules/once/once.js:17:25)
    at Stream.EventEmitter.emit (events.js:95:17)
    at Stream.onend (/Users/rtsao/tape-run/node_modules/tap-parser/index.js:142:16)
    at Stream.EventEmitter.emit (events.js:117:20)
    at Stream.<anonymous> (/Users/rtsao/tape-run/node_modules/tap-parser/node_modules/split/index.js:43:10)
    at _end (/Users/rtsao/tape-run/node_modules/tap-parser/node_modules/through/index.js:60:9)
make: *** [test] Error 8
```

This PR wraps the `server.destroy()` call in `browser-run/index.js:105` in a try/catch, which fixes the issue.

Alternatively, wrapping the `browser.stop()` call in `tape-run/index.js:17` also fixes the issue.

I'm unsure of the root cause. I am using OS X, if that helps.

I think this is related to https://github.com/juliangruber/tape-run/issues/23
