### PR TITLE
add phantomjs as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "concat-stream": "^1.5.1",
+    "phantomjs": "^2.1.3",
     "tap": "5.2.0",
     "utf8-stream": "0.0.0"
   },


### PR DESCRIPTION
Tests fail for me on fresh clone and install. Installing phantomjs fixes the problem.

I think due to the phantom test, phantomjs should be a devDependency.

```
~/browser-run master
❯ npm run test

> browser-run@3.0.8 test /Users/rtsao/browser-run
> make test

test/close.js ......................................... 2/2 815ms
test/empty.js ......................................... 1/1
test/error.js ......................................... 1/1 336ms
test/phantom.js ....................................... 0/3 30s
  phantomjs
  not ok Error: spawn ENOENT
    at:
      line: 988
      column: 11
      file: child_process.js
      function: errnoException
    stack: |
      errnoException (child_process.js:988:11)
      Process.ChildProcess._handle.onexit (child_process.js:779:34)
    code: ENOENT
    errno: ENOENT
    syscall: spawn
    test: phantomjs
    message: 'Error: spawn ENOENT'

  phantomjs
  not ok missing test
  not ok received SIGTERM with pending event queue activity
    requests: []
    handles:
      - type: Server
        events:
          - request
          - connection
          - clientError
        connectionKey: 'null:0.0.0.0:0'
      - type: Socket
        events:
          - end
          - finish
          - _socketEnd
          - close

test/spawn.js ......................................... 1/1 850ms
test/stream.js ........................................ 1/1 838ms
total ................................................. 6/9


  6 passing (33s)
  3 failing

make: *** [test] Error 1

npm ERR! Darwin 14.5.0
npm ERR! argv "node" "/Users/rtsao/.nvm/v0.10.26/bin/npm" "run" "test"
npm ERR! node v0.10.26
npm ERR! npm  v3.3.9
npm ERR! code ELIFECYCLE
npm ERR! browser-run@3.0.8 test: `make test`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the browser-run@3.0.8 test script 'make test'.
npm ERR! This is most likely a problem with the browser-run package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     make test
npm ERR! You can get their info via:
npm ERR!     npm owner ls browser-run
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/rtsao/browser-run/npm-debug.log
```