### PR TITLE
use tree-kill to kill spawned process in `test/spawn.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "browserify": "^13.0.0",
     "concat-stream": "^1.5.1",
     "tap": "5.2.0",
+    "tree-kill": "^1.0.0",
     "utf8-stream": "0.0.0"
   },
   "keywords": [

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -1,12 +1,13 @@
 var test = require('tap').test;
 var spawn = require('child_process').spawn;
+var kill = require('tree-kill');
 
 test('spawn', function (t) {
   var ps = spawn(__dirname + '/../bin/bin.js');
   
   ps.stdout.on('data', function (data) {
     t.equal(data.toString(), 'foo\n');
-    ps.kill();
+    kill(ps.pid);
     t.end();
   });
   ps.stderr.on('data', t.notOk.bind(t));


### PR DESCRIPTION
On my machine (OS X), the child electron process from the spawned `browser-run` process in `test/spawn.js` was not getting killed. Tests would pass, but an orphan electron process was left running.

I'm not totally sure of the root cause, but using `tree-kill` solves the issue. It's possible there is a better solution.