### PR TITLE
Added browser options to the runner

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -10,12 +10,15 @@ var argv = optimist
     'Usage: $0 [OPTIONS]'
   )
 
-  .describe('browser', 'Browser to use. '
-      + 'Always available: electron. '
-      + 'Available if installed: '
-      + 'chrome, firefox, ie, phantom, safari')
-  .alias('browser', 'b')
-  .default('browser', 'electron')
+  .describe('browser', '[Object|String]. Object with browser.name and browser.options fields. Or string to pass browser.name only.' +
+      '\n\tAlways available: electron. ' +
+      '\n\tOptions available: electron only. ' +
+      '\n\tAvailable if installed: chrome, firefox, ie, phantom, safari' +
+      '\n\tUsage: '+
+      '\n\t\t--browser=chrome - set browser name with no options passed.' +
+      '\n\t\t--browser.name=electron --browser.options.width=800 --browser.options.height=500 --browser.options.webPreferences.webSecurity=false - set browser and specify browser options.\n')
+  .alias('b', 'browser')
+  .default('browser.name', 'electron')
 
   .describe('port', 'Starts listening on that port and waits for you to open a browser')
   .alias('p', 'port')

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function (opts) {
   if (!opts) opts = {};
   if ('number' == typeof opts) opts = { port: opts };
   if (!opts.browser) opts.browser = 'electron';
+  if (!opts.browserOptions) opts.browserOptions = {};
   if (!opts.input) opts.input = 'javascript';
   return runner(opts);
 };
@@ -50,12 +51,12 @@ function runner (opts) {
       if (req.url == '/') {
         bundle.createReadStream().pipe(injectScript(['/reporter.js'])).pipe(res);
         return;
-      }      
+      }
     }
-    
+
     if (req.url == '/xws') {
       req.pipe(xws(function (stream) {
-        stream.pipe(output); 
+        stream.pipe(output);
       }));
       return req.on('end', res.end.bind(res));
     }
@@ -83,7 +84,7 @@ function runner (opts) {
       if (!address) return; // already closed
       var port = address.port;
 
-      launch('http://localhost:' + port, opts.browser, function(err, _browser){
+      launch('http://localhost:' + port, opts.browser, opts.browserOptions, function(err, _browser){
         if (err) return dpl.emit('error', err);
         browser = _browser;
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,12 @@ var destroyable = require('server-destroy');
 module.exports = function (opts) {
   if (!opts) opts = {};
   if ('number' == typeof opts) opts = { port: opts };
-  if (!opts.browser) opts.browser = 'electron';
-  if (!opts.browserOptions) opts.browserOptions = {};
+  if (!opts.browser || 'string' == typeof opts.browser) {
+    opts.browser = {
+      name: opts.browser || 'electron'
+    }
+  };
+  if (!opts.browser.options) opts.browser.options = {};
   if (!opts.input) opts.input = 'javascript';
   return runner(opts);
 };
@@ -84,7 +88,7 @@ function runner (opts) {
       if (!address) return; // already closed
       var port = address.port;
 
-      launch('http://localhost:' + port, opts.browser, opts.browserOptions, function(err, _browser){
+      launch('http://localhost:' + port, opts.browser.name, opts.browser.options, function(err, _browser){
         if (err) return dpl.emit('error', err);
         browser = _browser;
 

--- a/lib/launch.js
+++ b/lib/launch.js
@@ -2,13 +2,13 @@ var launcher = require('browser-launcher');
 var Phantom = require('phantomjs-stream');
 var Electron = require('electron-stream');
 
-module.exports = function(loc, name, cb){
+module.exports = function(loc, name, opts, cb){
   if (/^phantom/.test(name)) {
     var browser = Phantom();
     browser.end('location = ' + JSON.stringify(loc));
     process.nextTick(cb.bind(null, null, browser));
   }  else if (/^electron/.test(name)) {
-    var browser = Electron();
+    var browser = Electron(opts);
     browser.end('location = ' + JSON.stringify(loc));
     process.nextTick(cb.bind(null, null, browser));
   } else {

--- a/test/electron.js
+++ b/test/electron.js
@@ -1,0 +1,20 @@
+var test = require('tap').test;
+var run = require('..');
+
+test('electron-stream', function (t) {
+  var browser = run({
+    browser: 'electron',
+    browserOptions: {
+      height: 500
+    }
+  });
+
+  browser.on('data', function (data) {
+    browser.stop();
+    t.equal(data, '500\n', 'correct stdout');
+    t.end();
+  });
+
+  browser.end('console.log(window.outerHeight);');
+});
+

--- a/test/electron.js
+++ b/test/electron.js
@@ -3,9 +3,11 @@ var run = require('..');
 
 test('electron-stream', function (t) {
   var browser = run({
-    browser: 'electron',
-    browserOptions: {
-      height: 500
+    browser: {
+      name: 'electron',
+      options: {
+        height: 500
+      }
     }
   });
 


### PR DESCRIPTION
The tests for now will fail, because PR is dependent on https://github.com/juliangruber/electron-stream/pull/9

Other than that added the ability to pass the browserOptions object to configure Electron browser as per [documentation](https://github.com/atom/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions)
