### PR TITLE
add phantomjs-prebuilt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "concat-stream": "^1.5.1",
+    "phantomjs-prebuilt": "^2.1.7",
     "tap": "^5.7.2",
     "tree-kill": "^1.0.0",
     "utf8-stream": "^0.0.0"


### PR DESCRIPTION
This makes `npm i && npm t` work.

Related: https://github.com/juliangruber/phantomjs-stream/pull/9