### PR TITLE
use phantomjs-prebuilt-that-works

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "concat-stream": "^1.5.1",
-    "phantomjs-prebuilt": "^2.1.9",
+    "phantomjs-prebuilt-that-works": "^3.0.1",
     "tap": "^7.0.0",
     "tree-kill": "^1.0.0",
     "utf8-stream": "^0.0.0"


### PR DESCRIPTION
to get around the CDN rate limiting issues, this package implements an automatic fallback