### PR TITLE
update browser-launcher@1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "browser-launcher": "^1.0.0",
+    "browser-launcher": "^1.0.1",
     "duplexer": "^0.1.1",
     "ecstatic": "^2.0.0",
     "electron-stream": "^5.1.1",


### PR DESCRIPTION
browser-launcher had a security vulnerability caused by the `merge` package. the package was removed in https://github.com/substack/browser-launcher/commit/207e8c420f3f25adec1d77711159d36d422cbb72 and patched in 1.0.1.

it is the only change between two versions