### PR TITLE
ecstatic - npm audit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "browser-launcher": "^1.0.1",
     "duplexer": "^0.1.1",
-    "ecstatic": "^2.0.0",
+    "ecstatic": "^4.1.2",
     "electron-stream": "^5.1.1",
     "enstore": "^1.0.1",
     "html-inject-script": "^1.1.0",


### PR DESCRIPTION
npm audit won't pass on packages with current version of browser-run because of this high vulnerability on ecstatic 
https://www.npmjs.com/advisories/830

After this is merged, please update `tape-run` with the latest version of `browser-run`, and `browser-run` with the latest version of `electron-stream`