### PR TITLE
Add option to show electron window

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Usage: browser-run [OPTIONS]
 
 Options:
   --browser, -b  Browser to use. Always available: electron. Available if installed: chrome, firefox, ie, phantom, safari  [default: "electron"]
-  --port         Starts listening on that port and waits for you to open a browser
-  --static       Serve static assets from this directory
-  --mock         Path to code to handle requests for mocking a dynamic back-end
-  --input        Input type. Defaults to 'javascript', can be set to 'html'.
-  --node         Enable nodejs apis in electron
-  --show         Show browser window if browser is electron
-  --basedir      Set this if you need to require node modules in node mode
-  --help         Print help
+  --port         Starts listening on that port and waits for you to open a browser                                       
+  --static       Serve static assets from this directory                                                                 
+  --mock         Path to code to handle requests for mocking a dynamic back-end                                          
+  --input        Input type. Defaults to 'javascript', can be set to 'html'.                                             
+  --node         Enable nodejs apis in electron                                                                          
+  --show         Show browser window if browser is electron                                                              
+  --basedir      Set this if you need to require node modules in node mode                                               
+  --help         Print help 
 ```
 
 ## Custom html file

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ Usage: browser-run [OPTIONS]
 
 Options:
   --browser, -b  Browser to use. Always available: electron. Available if installed: chrome, firefox, ie, phantom, safari  [default: "electron"]
-  --port         Starts listening on that port and waits for you to open a browser                                       
-  --static       Serve static assets from this directory                                                                 
-  --mock         Path to code to handle requests for mocking a dynamic back-end                                          
-  --input        Input type. Defaults to 'javascript', can be set to 'html'.                                             
-  --node         Enable nodejs apis in electron                                                                          
-  --basedir      Set this if you need to require node modules in node mode                                               
-  --help         Print help 
+  --port         Starts listening on that port and waits for you to open a browser
+  --static       Serve static assets from this directory
+  --mock         Path to code to handle requests for mocking a dynamic back-end
+  --input        Input type. Defaults to 'javascript', can be set to 'html'.
+  --node         Enable nodejs apis in electron
+  --show         Show browser window if browser is electron
+  --basedir      Set this if you need to require node modules in node mode
+  --help         Print help
 ```
 
 ## Custom html file
@@ -98,6 +99,7 @@ Returns a duplex stream and starts a webserver.
 * `mock`: Path to code to handle requests for mocking a dynamic back-end
 * `input`: Input type. Defaults to `javascript`, can be set to `html`.
 * `node`: Enable nodejs integration in electron
+* `show`: Show browser window if browser is electron
 * `basedir`: Set this if you need to require node modules in `node` mode
 
 If only an empty string is written to it, an error will be thrown as there is nothing to execute.

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -32,6 +32,9 @@ var argv = optimist
   .describe('node', 'Enable nodejs apis in electron')
   .alias('n', 'node')
 
+  .describe('show', 'Show browser window if browser is electron')
+  .alias('w', 'show')
+
   .describe('basedir', 'Set this if you need to require node modules in node mode')
 
   .describe('help', 'Print help')


### PR DESCRIPTION
When testing in browser, I find it helpful at times to be able to view the window. This didn't appear possible when using electron as the browser. [electron-stream](https://github.com/juliangruber/electron-stream/blob/master/lib/runner.js#L13) already provides a `show` option, so I simply exposed the option via the [bin](https://github.com/tylerjpeterson/browser-run/blob/82b87f42726b99cdf877e1b2e14c609efcddb52b/bin/bin.js#L35-L36) script and updated the [README.md](https://github.com/tylerjpeterson/browser-run/blob/82b87f42726b99cdf877e1b2e14c609efcddb52b/README.md).

I assume this qualifies as a "trivial" update, so I am forgoing the process outlined in the contributing guidelines.