### PR TITLE
Use bleeding edge dependency to fix Firefox support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "browser-launcher": "^1.0.1",
+    "browser-launcher": "git+https://github.com/substack/browser-launcher.git#603e1ea",
     "duplexer": "^0.1.1",
     "ecstatic": "^4.1.2",
     "electron-stream": "^7.0.1",
@@ -36,6 +36,9 @@
     "tree-kill": "^1.0.0",
     "utf8-stream": "^0.0.0"
   },
+  "bundledDependencies": [
+    "browser-launcher"
+  ],
   "keywords": [
     "browser",
     "stream",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "browser-launcher": "git+https://github.com/substack/browser-launcher.git#603e1ea",
+    "browser-launcher": "substack/browser-launcher#603e1ea",
     "duplexer": "^0.1.1",
     "ecstatic": "^4.1.2",
     "electron-stream": "^7.0.1",


### PR DESCRIPTION
Fixes https://github.com/juliangruber/browser-run/issues/145
Fixes https://github.com/juliangruber/tape-run/issues/77

Uses the exact version directly from the original repo _and_ bundles it so it's still fast and `npm` doesn't need to use `git`