### PR TITLE
swap in yargs for optimist and patch a few other security vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.sw*
 node_modules
 static/reporter.js
+.nyc_output/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
   - 14

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-var yargs = require('yargs/yargs')
+
 var run = require('..');
+var yargs = require('yargs/yargs')
 
 var argv = yargs(process.argv.slice(2))
   .usage(

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
 var run = require('..');
-var optimist = require('optimist');
-
-var argv = optimist
+var argv = require('yargs/yargs')(process.argv.slice(2))
   .usage(
     'Run JavaScript in a browser.\n' +
     'Write code to stdin and receive console output on stdout.\n' +
@@ -34,13 +32,13 @@ var argv = optimist
 
   .describe('basedir', 'Set this if you need to require node modules in node mode')
 
+  .help('h')
   .describe('help', 'Print help')
   .alias('h', 'help')
 
   .argv;
 
 argv.nodeIntegration = argv['node-integration']
-if (argv.help) return optimist.showHelp();
 
 process.stdin
   .pipe(run(argv))

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-
+var yargs = require('yargs/yargs')
 var run = require('..');
-var argv = require('yargs/yargs')(process.argv.slice(2))
+
+var argv = yargs(process.argv.slice(2))
   .usage(
     'Run JavaScript in a browser.\n' +
     'Write code to stdin and receive console output on stdout.\n' +

--- a/package.json
+++ b/package.json
@@ -23,19 +23,19 @@
     "ecstatic": "^4.1.2",
     "electron-stream": "^8.0.0",
     "enstore": "^1.0.1",
-    "html-inject-script": "^1.1.0",
-    "optimist": "^0.6.1",
+    "html-inject-script": "^2.0.0",
     "server-destroy": "^1.0.1",
     "source-map-support": "^0.4.0",
     "through": "^2.3.8",
     "xhr-write-stream": "^0.1.2",
-    "xtend": "^4.0.1"
+    "xtend": "^4.0.1",
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "browserify": "^14.1.0",
     "concat-stream": "^1.5.1",
     "np": "^6.2.3",
-    "tap": "^10.0.1",
+    "tap": "^14.11.0",
     "tree-kill": "^1.0.0",
     "utf8-stream": "^0.0.0"
   },


### PR DESCRIPTION
hi there! 👋 

no offense taken if you aren't interested in this unsolicited pull request, but i thought i'd take a stab at resolving a few (possible) security vulnerabilities in my own upstream project.

before:
```
found 184 vulnerabilities (122 low, 7 moderate, 54 high, 1 critical)
```
after:
```
found 3 low severity vulnerabilities
```

this led to a few minor improvements in the help output.

before:
```
john@computer browser-run (yargs) $ ./bin/bin.js -h
Run JavaScript in a browser.
Write code to stdin and receive console output on stdout.
Usage: bin.js [OPTIONS]

Options:
  --browser, -b  Browser to use. Always available: electron. Available if installed: chrome, firefox, ie, safari  [default: "electron"]
  --port         Starts listening on that port and waits for you to open a browser
  --static       Serve static assets from this directory
  --mock         Path to code to handle requests for mocking a dynamic back-end
  --input        Input type. Defaults to 'javascript', can be set to 'html'.
  --node         Enable nodejs apis in electron
  --basedir      Set this if you need to require node modules in node mode
  --help         Print help
```
after:
(alphabetized, more aliases, new version option)
```
john@computer browser-run (yargs) $ ./bin/bin.js -h
Run JavaScript in a browser.
Write code to stdin and receive console output on stdout.
Usage: bin.js [OPTIONS]

Options:
      --version  Show version number                                   [boolean]
  -b, --browser  Browser to use. Always available: electron. Available if
                 installed: chrome, firefox, ie, safari    [default: "electron"]
      --basedir  Set this if you need to require node modules in node mode
  -h, --help     Print help                                            [boolean]
  -p, --port     Starts listening on that port and waits for you to open a
                 browser
  -s, --static   Serve static assets from this directory
  -m, --mock     Path to code to handle requests for mocking a dynamic back-end
  -i, --input    Input type. Defaults to 'javascript', can be set to 'html'.
  -n, --node     Enable nodejs apis in electron
```

and the TAP output now displays code coverage
```

  🌈 SUMMARY RESULTS 🌈


Suites:   8 passed, 8 of 8 completed
Asserts:  19 passed, of 19
Time:     17s
-----------------|----------|----------|----------|----------|-------------------|
File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------|----------|----------|----------|----------|-------------------|
All files        |    89.91 |    73.08 |    91.67 |    91.75 |                   |
 browser-run     |    89.13 |    71.74 |       90 |    90.12 |                   |
  index.js       |    89.13 |    71.74 |       90 |    90.12 |... 69,80,81,84,91 |
 browser-run/bin |      100 |      100 |      100 |      100 |                   |
  bin.js         |      100 |      100 |      100 |      100 |                   |
 browser-run/lib |    92.31 |    83.33 |      100 |      100 |                   |
  launch.js      |    92.31 |    83.33 |      100 |      100 |                15 |
-----------------|----------|----------|----------|----------|-------------------|
```

either way, thanks for your work on this project! 🙏 