### PR TITLE
Electron update for Apple M1 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "npm run build && tap test/*.js"
   },
   "dependencies": {
-    "browser-launcher": "git://github.com/fanatid/browser-launcher.git#426b9a791f855050b114a411d61b21cbd8e9f901",
+    "browser-launcher": "^3.0.1",
     "duplexer": "^0.1.1",
     "ecstatic": "^4.1.2",
     "electron-stream": "git://github.com/fanatid/electron-stream.git#01e9358e6c43d41381c446c3db58059ad1158998",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "test": "npm run build && tap test/*.js"
   },
   "dependencies": {
-    "browser-launcher": "^2.0.0",
+    "browser-launcher": "git://github.com/fanatid/browser-launcher.git#426b9a791f855050b114a411d61b21cbd8e9f901",
     "duplexer": "^0.1.1",
     "ecstatic": "^4.1.2",
-    "electron-stream": "^8.0.0",
+    "electron-stream": "git://github.com/fanatid/electron-stream.git#01e9358e6c43d41381c446c3db58059ad1158998",
     "enstore": "^1.0.1",
     "html-inject-script": "^2.0.0",
     "server-destroy": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "browser-launcher": "^3.0.1",
     "duplexer": "^0.1.1",
     "ecstatic": "^4.1.2",
-    "electron-stream": "git://github.com/fanatid/electron-stream.git#01e9358e6c43d41381c446c3db58059ad1158998",
+    "electron-stream": "^9.0.0",
     "enstore": "^1.0.1",
     "html-inject-script": "^2.0.0",
     "server-destroy": "^1.0.1",


### PR DESCRIPTION
This is temporary PR with a demonstration that things work. Once dependencies will be released PR will be updated.

Tracked PR:
- [x] https://github.com/juliangruber/electron-stream/pull/38
- [x] https://github.com/substack/browser-launcher/pull/52
- [x] https://github.com/substack/browser-launcher/pull/53